### PR TITLE
log the module name not the string "name"

### DIFF
--- a/sqstaskmaster/message_handler.py
+++ b/sqstaskmaster/message_handler.py
@@ -5,7 +5,7 @@ import time
 from abc import ABC, abstractmethod
 from botocore.exceptions import ClientError
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger(__name__)
 
 
 class MessageHandler(ABC):

--- a/sqstaskmaster/queue_scale.py
+++ b/sqstaskmaster/queue_scale.py
@@ -2,7 +2,7 @@ import logging
 import boto3
 from botocore.exceptions import ClientError
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger(__name__)
 
 
 class Provisioner:

--- a/sqstaskmaster/task_manager.py
+++ b/sqstaskmaster/task_manager.py
@@ -4,7 +4,7 @@ import json
 import boto3
 from json import JSONDecodeError
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger(__name__)
 
 
 class TaskManager:


### PR DESCRIPTION
Changes:
* Use `__name__` not `"__name__"` as the logger name.