### PR TITLE
Add LocalQueue implementation for integration testing applications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,14 @@ Consume Tasks
 
 
 Local Integration Testing
+
+Testing your production system should include a combination of: local stubbing using Mock; tools like
+`localstack <https://github.com/localstack/localstack>`_ or a staging environment to examine behavior in a distributed
+system; and purely local validation of consumer / producer api. LocalQueue is a pure in memory solution that implements
+a minimal subset of the SQS API for this last purpose only. The intent here is not to test or validate behavior of
+consumers and producers interacting with SQS, but only the message content. LocalQueue could be extended to implement
+threading and behave more like sqs within a single process, but that is better done with another tool like local stack.
+
 ::
 
   ...
@@ -102,8 +110,9 @@ Local Integration Testing
 
 By passing the queue_constructor argument to the TaskManager, you can bypass AWS SQS and use a local, in memory queue
 object to send and receive messages allowing local synchronous integration testing. This creates one global queue for
-each url. It is not for testing system behavior and does not implement retries, timeouts or other SQS features. It is
-only for integration testing of the interface between your producer and consumer methods.
+each url. It is not for testing system behavior and does not implement retries, message timeouts or other SQS features.
+It is only for integration testing of the interface between your producer and consumer methods with the TaskManager
+serialization and MessageHandler execution.
 
 Development
 ***********

--- a/README.rst
+++ b/README.rst
@@ -54,14 +54,36 @@ Usage
 Publish Tasks
 ::
 
-  TODO
+  tm = TaskManager(sqs_url)
+  tm.submit('MyTask', some='kwarg', someother='kwarg')
+  tm.submit('MyOtherTask', **kwargs)
 
+Create a Handler
+::
+
+  class MyHandler(MessageHandler):
+    def __init__(self, message, sqs_timeout, alarm_timeout, hard_timeout=4 * 60 * 60, **kwargs):
+        super().__init__(message, sqs_timeout, alarm_timeout, hard_timeout)
+        self.kwargs = kwargs
+        # prefer parsing arguments (for instance dates) in the consume task and passing explicit arguments
+
+    def running(self):
+        # If you can inspect the task to see if it is hung, do so here
+        return True
+
+    def run(self):
+        # Do some work here!
+
+    def notify(self, exception, context=None):
+        # Implement only for error notification service. Errors are already logged.
+        pass
 
 Consume Tasks
 ::
 
   for task, kwargs, message in TaskManager(sqs_url).task_generator(sqs_timeout=30):
     if task == 'MyTask':
+      # prefer parsing kwargs here and handle KeyError and ValueError appropriately
       with MyHandler(message, sqs_timeout=30, alarm_timeout=25, hard_timeout=300, **kwargs) as handler:
         handler.run()
     elif task == 'MyOtherTask':
@@ -70,6 +92,18 @@ Consume Tasks
     else:
       # Do something about unexpected task request
 
+
+Local Integration Testing
+::
+
+  ...
+  tm = TaskManager(url, queue_constructor=LocalQueue)
+  ...
+
+By passing the queue_constructor argument to the TaskManager, you can bypass AWS SQS and use a local, in memory queue
+object to send and receive messages allowing local synchronous integration testing. This creates one global queue for
+each url. It is not for testing system behavior and does not implement retries, timeouts or other SQS features. It is
+only for integration testing of the interface between your producer and consumer methods.
 
 Development
 ***********

--- a/sqstaskmaster/local.py
+++ b/sqstaskmaster/local.py
@@ -1,0 +1,138 @@
+import logging
+import time
+from collections import defaultdict
+import queue
+
+logger = logging.getLogger(__name__)
+"""
+Simple in memory unbounded SimpleQueue based implementation of AWS SQS for local development and integration testing.
+Not for use with threads or multiprocessing. MessageHandler class timeouts should behave as expected.
+No retry behavior is implemented.
+These classes are for synchronous integration testing of message producer and message consumer interface.
+These classes are not for use in production or for validating operational behavior of producer and consumer system.
+
+TODO Consider adding thread support by calling task_done in LocalMessage.delete
+"""
+
+
+class LocalMessage:
+    """
+    Partial implementation of the AWS SQS Message interface for local testing of the message producer and consumer.
+    This does not implement message behavior beyond the body and attributes used for encoded content.
+
+    Methods used by the MessageHandler class (change_visibility and delete) are No-ops!
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#message
+    """
+
+    def __init__(self, body, attributes, message_attributes):
+        """
+        This is not the same API as the AWS implementation!
+        :param body:
+        :param attributes:
+        """
+        self._body = body
+        self._attributes = attributes
+        self._message_attributes = message_attributes
+
+    @property
+    def attributes(self):
+        return self._attributes
+
+    @property
+    def body(self):
+        return self._body
+
+    @property
+    def message_attributes(self):
+        return self._message_attributes
+
+    def change_visibility(self, *args, **kwargs):
+        logger.info("noop called with %s, %s", args, kwargs)
+
+    def delete(self):
+        logger.info("noop delete")
+
+    def __str__(self):
+        return "LocalMessage(body: {}; attributes: {}; message_attributes: {})".format(
+            self.body, self.attributes, self.message_attributes
+        )
+
+
+class LocalQueue:
+    """
+    Partial implementation of the SQS Queue interface for local integration testing of the producer and consumer.
+    This does not implement behavior beyond the ability to put and get messages in FIFO order to a queue named by a url.
+
+    Some of the SQS features that are missing: Retries, visibility & timeout, thread/process safety.
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#queue
+    """
+
+    local_queues = defaultdict(queue.SimpleQueue)
+
+    def __init__(self, url):
+        self.url = url
+        self._queue = self.local_queues[url]
+
+    def load(self):
+        logger.info("Noop load!")
+
+    @property
+    def queue(self):
+        return self._queue
+
+    @property
+    def attributes(self):
+        logger.info("Noop attributes!")
+        # Return partial set of attributes
+        return {
+            "QueueArn": "LocalQueue replacing: " + self.url,
+            "ApproximateNumberOfMessages": self.queue.qsize(),
+            "ApproximateNumberOfMessagesNotVisible": 0,
+            "ApproximateNumberOfMessagesDelayed": 0,
+            "FifoQueue": True,
+            "ContentBasedDeduplication": False,
+        }
+
+    def purge(self):
+        while True:
+            try:
+                self.queue.get_nowait()
+            except queue.Empty:
+                break
+
+    def send_message(self, **kwargs):
+        """
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Queue.send_message
+        :param kwargs: expects MessageBody (String) and optional MessageAttributes (Dict)
+        :return: partial metadata of actual API
+        """
+        attributes = {}
+        # Ignore attribute behavior which is not relevant
+        message = LocalMessage(
+            kwargs["MessageBody"], attributes, kwargs.get("MessageAttributes", {})
+        )
+
+        logger.debug("Sending message: %s", message)
+        self.queue.put_nowait(message)
+        return {"MD5OfMessageBody": "Fake LocalMessage MD5 Body"}
+
+    def receive_messages(self, **kwargs):
+        """
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Queue.receive_messages
+        :param kwargs: simulates behavior of WaitTimeSeconds and MaxNumberOfMessages
+        :return:
+        """
+        time_remaining = kwargs.get("WaitTimeSeconds", 20)
+
+        result = []
+
+        tic = time.perf_counter()
+        for i in range(kwargs.get("MaxNumberOfMessages", 1)):
+            time_remaining = max(0, time_remaining - time.perf_counter() + tic)
+
+            try:
+                result.append(self.queue.get(block=True, timeout=time_remaining))
+            except queue.Empty:
+                break
+
+        return result

--- a/sqstaskmaster/message_handler.py
+++ b/sqstaskmaster/message_handler.py
@@ -101,7 +101,7 @@ class MessageHandler(ABC):
                 exc_val,
                 context={"body": self._message.body, **self._message.attributes},
             )
-            logger.exception("Failed for message %s", self._message)
+            logger.exception("Failed for message: %s", self._message)
 
         # catch only Exception not BaseException
         # https://docs.python.org/3/library/exceptions.html#exception-hierarchy

--- a/sqstaskmaster/tests/test_local.py
+++ b/sqstaskmaster/tests/test_local.py
@@ -1,0 +1,248 @@
+import logging
+import sys
+import time
+import unittest
+from _queue import SimpleQueue
+from unittest.mock import patch, call
+
+from sqstaskmaster.local import LocalMessage, LocalQueue
+from sqstaskmaster.message_handler import MessageHandler
+from sqstaskmaster.task_manager import TaskManager
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+
+
+class TestLocalMessage(unittest.TestCase):
+    def setUp(self):
+        self.instance = LocalMessage("body", {"some": "attr"}, {"some": "msg_attr"})
+
+    def test_init_properties(self):
+        self.assertEqual(self.instance.body, "body")
+        self.assertDictEqual(self.instance.attributes, {"some": "attr"})
+        self.assertDictEqual(self.instance.message_attributes, {"some": "msg_attr"})
+
+    @patch("sqstaskmaster.local.logger.info")
+    def test_change_visibility(self, mock_logger):
+        self.instance.change_visibility("arg1", somekwarg=5)
+        mock_logger.assert_called_once_with(
+            "noop called with %s, %s", ("arg1",), {"somekwarg": 5}
+        )
+
+    @patch("sqstaskmaster.local.logger.info")
+    def test_delete(self, mock_logger):
+        self.instance.delete()
+        mock_logger.assert_called_once_with("noop delete")
+
+
+class TestLocalQueue(unittest.TestCase):
+    def setUp(self):
+        LocalQueue.local_queues.clear()
+
+    def tearDown(self):
+        LocalQueue.local_queues.clear()
+
+    def test___init__(self):
+
+        lq1 = LocalQueue("url1")
+
+        self.assertEqual(lq1.url, "url1")
+        self.assertIsInstance(lq1.queue, SimpleQueue)
+
+        self.assertDictEqual(LocalQueue.local_queues, {"url1": lq1.queue})
+
+        lq2 = LocalQueue("url2")
+
+        self.assertEqual(lq2.url, "url2")
+        self.assertIsInstance(lq2.queue, SimpleQueue)
+
+        self.assertDictEqual(
+            LocalQueue.local_queues, {"url1": lq1.queue, "url2": lq2.queue}
+        )
+
+        self.assertIsNot(lq1.queue, lq2.queue)
+
+    @patch("sqstaskmaster.local.logger.info")
+    def test_load(self, mock_logger):
+        LocalQueue("url1").load()
+        mock_logger.assert_called_once_with("Noop load!")
+
+    def test_attributes(self):
+        self.assertDictEqual(
+            LocalQueue("url1").attributes,
+            {
+                "ApproximateNumberOfMessages": 0,
+                "ApproximateNumberOfMessagesDelayed": 0,
+                "ApproximateNumberOfMessagesNotVisible": 0,
+                "ContentBasedDeduplication": False,
+                "FifoQueue": True,
+                "QueueArn": "LocalQueue replacing: url1",
+            },
+        )
+
+    def test_purge(self):
+        lq = LocalQueue("url1")
+        lq.purge()
+        lq.send_message(MessageBody="the message body")
+        lq.send_message(MessageBody="the message body")
+        self.assertFalse(lq.queue.empty(), "Added a message - should not be empty")
+        lq.purge()
+        self.assertTrue(lq.queue.empty(), "Purged messages - should be empty")
+        # Does not raise or block when empty
+        lq.purge()
+
+    @patch("sqstaskmaster.local.LocalMessage")
+    def test_send_message(self, mock_cls):
+        with patch.object(LocalQueue, "queue") as mock_queue:
+            lq = LocalQueue("url1")
+            lq.send_message(MessageBody="the message body")
+            lq.send_message(
+                MessageBody="the second message body", MessageAttributes={"some": "kwd"}
+            )
+
+            # Will fail with additional __str__ calls if run at DEBUG
+            mock_cls.assert_has_calls(
+                [
+                    call("the message body", {}, {}),
+                    call("the second message body", {}, {"some": "kwd"}),
+                ]
+            )
+
+            mock_queue.put_nowait.assert_has_calls(
+                [call(mock_cls.return_value), call(mock_cls.return_value)]
+            )
+
+    @patch("sqstaskmaster.local.LocalMessage")
+    def test_receive_messages(self, mock_cls):
+
+        lq = LocalQueue("url1")
+
+        for _ in range(5):
+            lq.send_message(MessageBody="the message body")
+
+        result = lq.receive_messages(WaitTimeSeconds=0, MaxNumberOfMessages=3)
+        self.assertListEqual(result, [mock_cls.return_value for _ in range(3)])
+
+        result = lq.receive_messages(WaitTimeSeconds=0, MaxNumberOfMessages=3)
+        self.assertListEqual(result, [mock_cls.return_value for _ in range(2)])
+
+    @patch("sqstaskmaster.local.LocalMessage")
+    def test_receive_messages_timeout(self, mock_cls):
+        lq = LocalQueue("url1")
+        lq.send_message(MessageBody="the message body")
+
+        tic = time.perf_counter()
+        result = lq.receive_messages(WaitTimeSeconds=1, MaxNumberOfMessages=3)
+        toc = time.perf_counter()
+
+        self.assertListEqual(result, [mock_cls.return_value])
+        self.assertGreater(toc - tic, 1.0, "Should wait upto 1 second")
+        self.assertLess(
+            toc - tic, 1.05, "Should not take more then 5/100th of second to return"
+        )
+
+
+TASK_NAME, TASK_STOP = "special_task", "STOP"
+
+
+def example_producer(url, messages):
+    """
+    Typically the producer is a runnable main that is scheduled, triggered or run manually to enqueue tasks
+    :param url: the sqs url
+    :param messages: the tuple of TASK and KWARGS
+    """
+    tm = TaskManager(url, queue_constructor=LocalQueue)
+    for task, kwargs in messages:
+        tm.submit(task, **kwargs)
+    logger.info("Submitted messages")
+
+
+class MyHandler(MessageHandler):
+    def __init__(
+        self,
+        message,
+        sqs_timeout,
+        alarm_timeout,
+        run_method,
+        hard_timeout=4 * 60 * 60,
+        **kwargs
+    ):
+        super().__init__(message, sqs_timeout, alarm_timeout, hard_timeout)
+        self.kwargs = kwargs
+        self.run_method = run_method
+
+    def running(self):
+        return True
+
+    def run(self):
+        self.run_method(**self.kwargs)
+
+    def notify(self, exception, context=None):
+        pass
+
+
+def example_consumer(url, do_method):
+    """
+    Consumer is typically a runnable main that is deployed to execute a tasks.
+    This method demonstrates how the integration with the message publisher might be tested
+    :param url: the sqs url
+    :param do_method: hook to provide a method that allows message content validation.
+    """
+    tm = TaskManager(url, queue_constructor=LocalQueue)
+
+    for task, kwargs, message in tm.task_generator(sqs_timeout=30, wait_time=1):
+        logger.info("got task %s with %s and %s", task, kwargs, message)
+        if task == TASK_NAME:
+            with MyHandler(
+                message,
+                sqs_timeout=5,
+                alarm_timeout=1,
+                run_method=do_method,
+                hard_timeout=1,
+                **kwargs
+            ) as handler:
+                logger.info("Calling run method")
+                handler.run()
+        elif task == TASK_STOP:
+            # typically a deployed consumer would run indefinitely waiting for work
+            logger.info("Calling Break for STOP task!")
+            break
+        else:
+            logger.info("Got unexpected task name: %s with message %s", task, message)
+
+
+class TestLocalIntegration(unittest.TestCase):
+    def test_producer_consumer(self):
+        messages = [
+            (TASK_NAME, {"some": "value"}),
+            (TASK_NAME, {"some": "other value"}),
+            (TASK_NAME, {"some": "more values"}),
+            (TASK_NAME, {"some": None}),
+            (TASK_STOP, {"more": "nonesense"}),
+        ]
+
+        example_producer("a_particular_queue", messages)
+        received = []
+
+        def receiver(**kwargs):
+            logger.info("receiver method got %s", kwargs)
+            received.append(kwargs)
+
+        example_consumer("a_particular_queue", receiver)
+
+        self.assertListEqual([k for t, k in messages if t == TASK_NAME], received)
+
+    def test_producer_consumer_timeout(self):
+        messages = [(TASK_NAME, {"some": None}), (TASK_STOP, {"more": "nonesense"})]
+
+        example_producer("a_particular_queue", messages)
+        received = []
+
+        def receiver(**kwargs):
+            logger.info("receiver method got %s", kwargs)
+            received.append(kwargs)
+            time.sleep(2)
+
+        example_consumer("a_particular_queue", receiver)
+
+        self.assertListEqual([k for t, k in messages if t == TASK_NAME], received)

--- a/sqstaskmaster/tests/test_message_handler.py
+++ b/sqstaskmaster/tests/test_message_handler.py
@@ -163,7 +163,7 @@ class TestMessageHandler(unittest.TestCase):
         mock_message.delete.assert_not_called()
         mock_alarm.assert_called_once_with(0)
         mock_logger.exception.assert_called_once_with(
-            "Failed for message %s", mock_message
+            "Failed for message: %s", mock_message
         )
         notify.assert_called_once_with(
             exc_val, context={"body": mock_message.body, **mock_message.attributes}
@@ -236,7 +236,7 @@ class TestMessageHandler(unittest.TestCase):
         mock_alarm.assert_called_once_with(0)
 
         mock_log.exception.assert_called_once_with(
-            "Failed for message %s", mock_message
+            "Failed for message: %s", mock_message
         )
         notify.assert_called_once_with(
             error, context={"body": mock_message.body, **mock_message.attributes}
@@ -266,7 +266,7 @@ class TestMessageHandler(unittest.TestCase):
         mock_alarm.assert_called_once_with(0)
 
         mock_log.exception.assert_called_once_with(
-            "Failed for message %s", mock_message
+            "Failed for message: %s", mock_message
         )
         notify.assert_called_once_with(
             error, context={"body": mock_message.body, **mock_message.attributes}
@@ -298,7 +298,7 @@ class TestMessageHandler(unittest.TestCase):
         mock_alarm.assert_called_once_with(0)
 
         mock_log.exception.assert_called_once_with(
-            "Failed for message %s", mock_message
+            "Failed for message: %s", mock_message
         )
         notify.assert_called_once_with(
             error, context={"body": mock_message.body, **mock_message.attributes}


### PR DESCRIPTION
Simple in memory unbounded SimpleQueue based implementation of AWS SQS for local development and integration testing.
Not for use with threads or multiprocessing. MessageHandler class timeouts should behave as expected. No retry behavior is implemented.

These classes are for synchronous integration testing of message producer and message consumer interface.

These classes are not for use in production or for validating operational behavior of producer and consumer system.

Changes:
* Add LocalQueue implementation of send and receive behavior of boto3 SQS
* Add LocalMessage implementation of boto3 Message 
* Add kwarg to use LocalQueue in TaskManger
* Update readme with better examples
