### PR TITLE
Add suggested service state check

### DIFF
--- a/sqstaskmaster/queue_scale.py
+++ b/sqstaskmaster/queue_scale.py
@@ -135,7 +135,7 @@ class Provisioner:
         The api specifies the ability to get the tags, but by observation they are not returned even when requested.
         Use get_tags.
         """
-        result = self.ecs.get_description(
+        result = self.ecs.describe_services(
             cluster=rule[self.CLUSTER_NAME],
             services=[rule[self.SERVICE_NAME]],
             include=[

--- a/sqstaskmaster/tests/test_queue_scale.py
+++ b/sqstaskmaster/tests/test_queue_scale.py
@@ -120,13 +120,13 @@ class TestBatchJobResourceMonitorTask(unittest.TestCase):
         provisioner = queue_scale.Provisioner([self.RULE])
 
         mock_result = Mock()
-        boto3.client.return_value.get_description.return_value = {
+        boto3.client.return_value.describe_services.return_value = {
             "services": [mock_result],
             "failures": [],
         }
 
         self.assertEqual(mock_result, provisioner.get_description(self.RULE))
-        boto3.client.return_value.get_description.assert_called_once_with(
+        boto3.client.return_value.describe_services.assert_called_once_with(
             cluster=self.RULE[provisioner.CLUSTER_NAME],
             services=[self.RULE[provisioner.SERVICE_NAME]],
             include=["TAGS"],
@@ -135,13 +135,13 @@ class TestBatchJobResourceMonitorTask(unittest.TestCase):
     def test_get_description_failure(self, boto3):
         provisioner = queue_scale.Provisioner([self.RULE])
 
-        boto3.client.return_value.get_description.return_value = {
+        boto3.client.return_value.describe_services.return_value = {
             "services": [],
             "failures": [{"arn": "some_arn", "reason": "MISSING"}],
         }
 
         self.assertDictEqual({}, provisioner.get_description(self.RULE))
-        boto3.client.return_value.get_description.assert_called_once_with(
+        boto3.client.return_value.describe_services.assert_called_once_with(
             cluster=self.RULE[provisioner.CLUSTER_NAME],
             services=[self.RULE[provisioner.SERVICE_NAME]],
             include=["TAGS"],

--- a/sqstaskmaster/tests/test_queue_scale.py
+++ b/sqstaskmaster/tests/test_queue_scale.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, Mock
 from botocore.exceptions import ClientError
 
 from sqstaskmaster import queue_scale
+from sqstaskmaster.queue_scale import ServiceState
 
 
 @patch("sqstaskmaster.queue_scale.boto3")
@@ -57,7 +58,11 @@ class TestBatchJobResourceMonitorTask(unittest.TestCase):
         boto3.resource.return_value.Queue.return_value.attributes = {
             name: "2" for name in provisioner.QUEUE_DEPTH_ATTRIBUTES.values()
         }
-        provisioner.run()
+
+        with patch.object(
+            queue_scale.Provisioner, "service_state", lambda _, __: ServiceState.ACTIVE
+        ):
+            provisioner.run()
 
         boto3.resource.return_value.Queue.assert_called_with(
             self.RULE[provisioner.QUEUE_NAME]
@@ -69,13 +74,14 @@ class TestBatchJobResourceMonitorTask(unittest.TestCase):
         )
 
     def test_run_without_messages(self, boto3):
-
         provisioner = queue_scale.Provisioner([self.RULE])
         boto3.resource.return_value.Queue.return_value.attributes = {
             name: "0" for name in provisioner.QUEUE_DEPTH_ATTRIBUTES.values()
         }
-        provisioner.run()
-
+        with patch.object(
+            queue_scale.Provisioner, "service_state", lambda _, __: ServiceState.ACTIVE
+        ):
+            provisioner.run()
         boto3.resource.return_value.Queue.assert_called_with(
             self.RULE[provisioner.QUEUE_NAME]
         )
@@ -91,9 +97,90 @@ class TestBatchJobResourceMonitorTask(unittest.TestCase):
         ce = ClientError({}, "operation")
         provisioner = queue_scale.Provisioner([self.RULE], notify=notify)
         boto3.resource.return_value.Queue.side_effect = Mock(side_effect=ce)
-        provisioner.run()
-
+        with patch.object(
+            queue_scale.Provisioner, "service_state", lambda _, __: ServiceState.ACTIVE
+        ):
+            provisioner.run()
         log.exception.assert_called_once_with(
             "Failed to update resources for rule %s", self.RULE
         )
         notify.assert_called_once_with(ce, context=self.RULE)
+
+    def test_run_with_status_not_active(self, boto3):
+        provisioner = queue_scale.Provisioner([self.RULE])
+        with patch.object(
+            queue_scale.Provisioner,
+            "service_state",
+            lambda _, __: ServiceState.STARTING,
+        ):
+            provisioner.run()
+        boto3.client.return_value.update_service.assert_not_called()
+
+    def test_get_description_success(self, boto3):
+        provisioner = queue_scale.Provisioner([self.RULE])
+
+        mock_result = Mock()
+        boto3.client.return_value.get_description.return_value = {
+            "services": [mock_result],
+            "failures": [],
+        }
+
+        self.assertEqual(mock_result, provisioner.get_description(self.RULE))
+        boto3.client.return_value.get_description.assert_called_once_with(
+            cluster=self.RULE[provisioner.CLUSTER_NAME],
+            services=[self.RULE[provisioner.SERVICE_NAME]],
+            include=["TAGS"],
+        )
+
+    def test_get_description_failure(self, boto3):
+        provisioner = queue_scale.Provisioner([self.RULE])
+
+        boto3.client.return_value.get_description.return_value = {
+            "services": [],
+            "failures": [{"arn": "some_arn", "reason": "MISSING"}],
+        }
+
+        self.assertDictEqual({}, provisioner.get_description(self.RULE))
+        boto3.client.return_value.get_description.assert_called_once_with(
+            cluster=self.RULE[provisioner.CLUSTER_NAME],
+            services=[self.RULE[provisioner.SERVICE_NAME]],
+            include=["TAGS"],
+        )
+
+    def test_list_tags_success(self, boto3):
+        provisioner = queue_scale.Provisioner([self.RULE])
+        boto3.client.return_value.list_tags_for_resource.return_value = {
+            "tags": [{"key": "string", "value": "string"}]
+        }
+        self.assertListEqual(
+            [{"key": "string", "value": "string"}], provisioner.get_tags("foo_arn")
+        )
+        boto3.client.return_value.list_tags_for_resource.assert_called_once_with(
+            resourceArn="foo_arn"
+        )
+
+    def test_list_tags_failure(self, boto3):
+        """
+        Example of actual Error:
+        InvalidParameterException: An error occurred (InvalidParameterException) when calling the ListTagsForResource
+        operation: The service with name {YOUR BAD ARN} cannot be found. Specify a valid service name and try again.
+
+        InvalidParameterException inherits from ClientError, but can not be directly imported for testing / handling.
+        """
+        provisioner = queue_scale.Provisioner([self.RULE])
+        ce = ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidParameterException",
+                    "Message": "Stuff happens...",
+                }
+            },
+            "ListTagsForResource",
+        )
+        boto3.client.return_value.list_tags_for_resource.side_effect = ce
+        with self.assertRaisesRegex(
+            ClientError,
+            r"An error occurred \(InvalidParameterException\) when calling the ListTagsForResource operation: "
+            r"Stuff happens...",
+        ):
+            provisioner.get_tags("foo_arn")


### PR DESCRIPTION

Changes:
* Add suggested service state check before provisioner changes desiredCount

This can help prevent race conditions during deployment of services and provisioner